### PR TITLE
Simple support for kitty via fat layout

### DIFF
--- a/kakmerge
+++ b/kakmerge
@@ -121,10 +121,11 @@ log_fatal() {
 }
 
 usage() {
-    log_msg "Usage: $0 [-h] [-c <cmd>] [data]...
+    log_msg "Usage: $0 [-h] [-m <multiplexer>] [-c <cmd>] [data]...
 
 Options:
-  -c <cmd> Execute command <cmd> (default: merge), can be one of: merge, abort, done, pick
+  -m {tmux,kitty}  Use a specific terminal multiplexer (default: tmux)
+  -c <cmd>         Execute command <cmd> (default: merge), can be one of: merge, abort, done, pick
 
 Meta-data can be passed to the commands, and varies accordingly:
   merge                              Spawn instances of Kakoune to resolve the merge conflict

--- a/kakmerge
+++ b/kakmerge
@@ -162,6 +162,28 @@ do_create_layout_tmux() {
         select-pane -D
 }
 
+do_create_layout_kitty() {
+    kak_session="${1}"
+
+    kitty @ goto-layout fat
+    kitty @ new-window kak -c "${kak_session}" \
+                       -e '
+                       rename-client local
+                       rename-session %{'"${kak_session}"'}
+                       ' >/dev/null
+    kitty @ new-window kak -c "${kak_session}" \
+                       -e '
+                       rename-client base
+                       rename-session %{'"${kak_session}"'}
+                       ' >/dev/null
+    kitty @ new-window kak -c "${kak_session}" \
+                       -e '
+                       rename-client remote
+                       rename-session %{'"${kak_session}"'}
+                       ' >/dev/null
+    kitty @ focus-window --match id:"${KITTY_WINDOW_ID}"
+}
+
 cmd_merge() {
     multiplexer="${1}"
     kak_session="kakmerge-$$"
@@ -177,6 +199,10 @@ cmd_merge() {
 
     if [ -n "${TMUX}" ]; then
         do_create_layout="do_create_layout_tmux"
+    fi
+
+    if [ -n "${KITTY_WINDOW_ID}" ]; then
+        do_create_layout="do_create_layout_kitty"
     fi
 
     if [ -z "${do_create_layout}" ]; then

--- a/kakmerge
+++ b/kakmerge
@@ -167,6 +167,8 @@ do_create_layout_kitty() {
     kak_session="${1}"
 
     kitty @ goto-layout fat
+    [ $? -ne 0 ] && exit 1  # kitty prints a nice message if it doesn't support remote control
+
     kitty @ new-window kak -c "${kak_session}" \
                        -e '
                        rename-client local

--- a/kakmerge
+++ b/kakmerge
@@ -206,7 +206,7 @@ cmd_merge() {
     fi
 
     if [ -z "${do_create_layout}" ]; then
-        log_fatal "Unsupported multiplexer ${multiplexer}"
+        log_fatal "Unsupported multiplexer"
     fi
 
     eval "${do_create_layout} '${kak_session}'"

--- a/kakmerge
+++ b/kakmerge
@@ -275,8 +275,7 @@ cmd_pick() {
 
     case "${which}" in
         "local"|"base"|"remote");;
-        *)
-            log_fatal "Unsupported file version: ${which}";;
+        *) log_fatal "Unsupported file version: ${which}";;
     esac
 
     if [ -z "${LOCAL}" ] || [ -z "${BASE}" ] || [ -z "${REMOTE}" ] || [ -z "${MERGED}" ]; then
@@ -317,14 +316,12 @@ main() {
 
     case "${command}" in
         "merge"|"abort"|"done"|"pick");;
-        *)
-            log_fatal "Unsupported command: ${command}";;
+        *) log_fatal "Unsupported command: ${command}";;
     esac
 
     case "${multiplexer}" in
         ""|"tmux"|"kitty");;
-        *)
-            log_fatal "Unsupported multiplexer: ${multiplexer}";;
+        *) log_fatal "Unsupported multiplexer: ${multiplexer}";;
     esac
 
     eval "cmd_${command} '${multiplexer}'" "$@"

--- a/kakmerge
+++ b/kakmerge
@@ -180,19 +180,19 @@ do_create_layout_kitty() {
                        -e '
                        rename-client local
                        rename-session %{'"${kak_session}"'}
-                       exec %sh{ kill '"${wait_local}"' }
+                       nop %sh{ kill '"${wait_local}"' }
                        ' >/dev/null
     kitty @ new-window kak -c "${kak_session}" \
                        -e '
                        rename-client base
                        rename-session %{'"${kak_session}"'}
-                       exec %sh{ kill '"${wait_base}"' }
+                       nop %sh{ kill '"${wait_base}"' }
                        ' >/dev/null
     kitty @ new-window kak -c "${kak_session}" \
                        -e '
                        rename-client remote
                        rename-session %{'"${kak_session}"'}
-                       exec %sh{ kill '"${wait_remote}"' }
+                       nop %sh{ kill '"${wait_remote}"' }
                        ' >/dev/null
     kitty @ focus-window --match id:"${KITTY_WINDOW_ID}"
     wait "${wait_local}" "${wait_base}" "${wait_remote}"

--- a/kakmerge
+++ b/kakmerge
@@ -265,9 +265,7 @@ cmd_pick() {
     case "${which}" in
         "local"|"base"|"remote");;
         *)
-            log_error "Unsupported file version: ${which}"
-            usage
-            exit 1;;
+            log_fatal "Unsupported file version: ${which}";;
     esac
 
     if [ -z "${LOCAL}" ] || [ -z "${BASE}" ] || [ -z "${REMOTE}" ] || [ -z "${MERGED}" ]; then
@@ -309,17 +307,13 @@ main() {
     case "${command}" in
         "merge"|"abort"|"done"|"pick");;
         *)
-            log_error "Unsupported command: ${command}"
-            usage
-            exit 1;;
+            log_fatal "Unsupported command: ${command}";;
     esac
 
     case "${multiplexer}" in
         ""|"tmux"|"kitty");;
         *)
-            log_error "Unsupported multiplexer: ${multiplexer}"
-            usage
-            exit 1;;
+            log_fatal "Unsupported multiplexer: ${multiplexer}";;
     esac
 
     eval "cmd_${command} '${multiplexer}'" "$@"

--- a/kakmerge
+++ b/kakmerge
@@ -169,22 +169,33 @@ do_create_layout_kitty() {
     kitty @ goto-layout fat
     [ $? -ne 0 ] && exit 1  # kitty prints a nice message if it doesn't support remote control
 
+    sleep 10 &
+    wait_local=$!
+    sleep 10 &
+    wait_base=$!
+    sleep 10 &
+    wait_remote=$!
+
     kitty @ new-window kak -c "${kak_session}" \
                        -e '
                        rename-client local
                        rename-session %{'"${kak_session}"'}
+                       exec %sh{ kill '"${wait_local}"' }
                        ' >/dev/null
     kitty @ new-window kak -c "${kak_session}" \
                        -e '
                        rename-client base
                        rename-session %{'"${kak_session}"'}
+                       exec %sh{ kill '"${wait_base}"' }
                        ' >/dev/null
     kitty @ new-window kak -c "${kak_session}" \
                        -e '
                        rename-client remote
                        rename-session %{'"${kak_session}"'}
+                       exec %sh{ kill '"${wait_remote}"' }
                        ' >/dev/null
     kitty @ focus-window --match id:"${KITTY_WINDOW_ID}"
+    wait "${wait_local}" "${wait_base}" "${wait_remote}"
 }
 
 cmd_merge() {

--- a/kakmerge
+++ b/kakmerge
@@ -169,11 +169,12 @@ do_create_layout_kitty() {
     kitty @ goto-layout fat
     [ $? -ne 0 ] && log_fatal "It is required to enable remote control in kitty"
 
-    sleep 10 &
+    infinity=2147483647
+    sleep "${infinity}" &
     wait_local=$!
-    sleep 10 &
+    sleep "${infinity}" &
     wait_base=$!
-    sleep 10 &
+    sleep "${infinity}" &
     wait_remote=$!
 
     kitty @ new-window kak -c "${kak_session}" \
@@ -195,7 +196,7 @@ do_create_layout_kitty() {
                        nop %sh{ kill '"${wait_remote}"' }
                        ' >/dev/null
     kitty @ focus-window --match id:"${KITTY_WINDOW_ID}"
-    wait "${wait_local}" "${wait_base}" "${wait_remote}"
+    wait "${wait_local}" "${wait_base}" "${wait_remote}" >/dev/null
 }
 
 cmd_merge() {

--- a/kakmerge
+++ b/kakmerge
@@ -167,7 +167,7 @@ do_create_layout_kitty() {
     kak_session="${1}"
 
     kitty @ goto-layout fat
-    [ $? -ne 0 ] && exit 1  # kitty prints a nice message if it doesn't support remote control
+    [ $? -ne 0 ] && log_fatal "It is required to enable remote control in kitty"
 
     sleep 10 &
     wait_local=$!

--- a/kakmerge
+++ b/kakmerge
@@ -198,9 +198,7 @@ cmd_merge() {
     kak -d -s "${kak_session}" -E "${KAKMERGE_CMDS}" || log_fatal "Unable to spawn a Kakoune server"
 
     if [ -n "${multiplexer}" ]; then
-        if type "do_create_layout_${multiplexer}" >/dev/null; then
-            do_create_layout="do_create_layout_${multiplexer}"
-        fi
+        do_create_layout="do_create_layout_${multiplexer}"
     elif [ -n "${TMUX}" ]; then
         do_create_layout="do_create_layout_tmux"
     elif [ -n "${KITTY_WINDOW_ID}" ]; then
@@ -309,6 +307,14 @@ main() {
         "merge"|"abort"|"done"|"pick");;
         *)
             log_error "Unsupported command: ${command}"
+            usage
+            exit 1;;
+    esac
+
+    case "${multiplexer}" in
+        ""|"tmux"|"kitty");;
+        *)
+            log_error "Unsupported multiplexer: ${multiplexer}"
             usage
             exit 1;;
     esac

--- a/kakmerge
+++ b/kakmerge
@@ -197,16 +197,18 @@ cmd_merge() {
 
     kak -d -s "${kak_session}" -E "${KAKMERGE_CMDS}" || log_fatal "Unable to spawn a Kakoune server"
 
-    if [ -n "${TMUX}" ]; then
+    if [ -n "${multiplexer}" ]; then
+        if type "do_create_layout_${multiplexer}" >/dev/null; then
+            do_create_layout="do_create_layout_${multiplexer}"
+        fi
+    elif [ -n "${TMUX}" ]; then
         do_create_layout="do_create_layout_tmux"
-    fi
-
-    if [ -n "${KITTY_WINDOW_ID}" ]; then
+    elif [ -n "${KITTY_WINDOW_ID}" ]; then
         do_create_layout="do_create_layout_kitty"
     fi
 
     if [ -z "${do_create_layout}" ]; then
-        log_fatal "Unsupported multiplexer"
+        log_fatal "Unsupported multiplexer ${multiplexer}"
     fi
 
     eval "${do_create_layout} '${kak_session}'"


### PR DESCRIPTION
Kitty allows to create windows and has a few built-in layouts, the most resembling layout is called `fat` and that's what I used.

With kitty and no tmux this is how executing `./test.sh` looks:

![image](https://user-images.githubusercontent.com/1177900/48871601-b123b080-ede5-11e8-9fb1-8e3b55db5fe0.png)
